### PR TITLE
fix pd.to_datetime inferring date incorrectly

### DIFF
--- a/istatapi/retrieval.py
+++ b/istatapi/retrieval.py
@@ -27,7 +27,7 @@ def get_data(dataset: DataSet, **kwargs):
 
     if "TIME_PERIOD" in df.columns:
         df["TIME_PERIOD"] = pd.to_datetime(
-            df["TIME_PERIOD"], infer_datetime_format=True
+            df["TIME_PERIOD"].astype(str), infer_datetime_format=True
         )
         df = df.sort_values(by=["TIME_PERIOD"])
 

--- a/nbs/03_retrieval.ipynb
+++ b/nbs/03_retrieval.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "    if \"TIME_PERIOD\" in df.columns:\n",
     "        df[\"TIME_PERIOD\"] = pd.to_datetime(\n",
-    "            df[\"TIME_PERIOD\"], infer_datetime_format=True\n",
+    "            df[\"TIME_PERIOD\"].astype(str), infer_datetime_format=True\n",
     "        )\n",
     "        df = df.sort_values(by=[\"TIME_PERIOD\"])\n",
     "\n",


### PR DESCRIPTION
Hi, 
thanks for making this nice python API!

I'm fixing a small bug: when data of `TIME_PERIOD` is presented as integers, e.g., for years, the pandas function `to_datetime` infer incorrectly the value as microseconds from the reference datetime `1970-01-01-00:00:00.000`. To fix this, I simply convert the number to string.

Working fine with pandas==1.5.3.